### PR TITLE
feat(su): use `rust` and `rust:slim` docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ each other yet.
       Web to makes calls the Arweave gateway on the wrong port.
     - ⚠️ ArDrive Web is using so-called "sandboxed urls" where it contacts the gateway on a subdomain that is
       the base32 encoded transaction id of the Arweave transaction.
-      - _This can be suppress by adding `127.0.0.1 *.localhost` to your `/etc/hosts` file._
+      - _This can be mitigated by adding `127.0.0.1 *.localhost` to your `/etc/hosts` file._
 - ⚠️ Fully functional `ao` computer, using the
   [reference implementations](https://github.com/permaweb/ao/servers).
   - `cu`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     build: ./services/su
     configs:
       - source: ao-wallet
-        target: /usr/app/ao-wallet.json
+        target: /app/ao-wallet.json
     env_file: ./services/su/.env
     ports:
       - 4003:80

--- a/services/su/.env
+++ b/services/su/.env
@@ -1,4 +1,4 @@
-SU_WALLET_PATH=/usr/app/ao-wallet.json
+SU_WALLET_PATH=/app/ao-wallet.json
 DATABASE_URL=postgresql://su_user:su_pass@su-database/su_db
 GATEWAY_URL=http://arlocal/
 UPLOAD_NODE_URL=https://up.arweave.net

--- a/services/su/Dockerfile
+++ b/services/su/Dockerfile
@@ -6,15 +6,17 @@ RUN apk add git
 WORKDIR /download
 RUN git clone --branch=${SU_VERSION} --depth=1 https://github.com/permaweb/ao.git
 
-FROM clux/muslrust:1.75.0 as builder
-COPY --from=downloader /download/ao/servers/su /usr/src
-WORKDIR /usr/src
+FROM rust AS builder
+WORKDIR /build
+COPY --from=downloader /download/ao/servers/su .
 
-RUN cargo build --release --target x86_64-unknown-linux-musl
+RUN cargo build --release
 
-FROM alpine:latest
-COPY --from=builder /usr/src/target/x86_64-unknown-linux-musl/release/su /usr/app/su
-WORKDIR /usr/app
+FROM rust:slim
+WORKDIR /app
+COPY --from=builder /build/target/release/su .
+
+RUN apt update && apt install --yes libpq5
 
 EXPOSE 80
 CMD ["./su", "su", "80"]


### PR DESCRIPTION
seems to work better on Apple silicon