### PR TITLE
feat(aos): add script to launch `aos`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+> [!CAUTION]
+> **This is an experimental repo that is intended for power users developing core aspects of the `ao`
+> computer, new `ao` unit implementations, or custom `ao` modules.**
+>
+> **As such, this repo may become out-of-date and may not work out-of-the-box, and novice developers
+> _will not_ be given much support.**
+>
+> **If you want to run `aos` processes, please refer to its
+> [source code](https://github.com/permaweb/aos) or the
+> [`ao` cookbook](https://cookbook_ao.arweave.dev/welcome/index.html).**
+
 # ao-localnet
 
 Run a complete [AO Computer](http://ao.computer/) testbed, locally, with Docker Compose.
@@ -10,83 +21,93 @@ The repo may helpful if you are doing one or more of the following:
 1. Compiling `ao` modules using the `ao` [dev-cli](https://github.com/permaweb/dev-cli).
    - And you want to avoid publishing each revision onto Arweave mainnet.
 1. You are developing an `ao` component (e.g. a `cu`, `mu`, or `su`).
-   - And you want to swap that into a working environment.
+   - And you want to plug that into a working environment.
 1. You are developing Lua code that will be loaded into `aos` processes.
    - And you want to avoid bricking your `aos` processes on `ao` testnet.
 
-## How to Run a Localnet
+## Quick Start Guide
 
-> [!WARNING]
-> Later steps may not be fully functional
+1. Clone this repo.
+1. Setup the necessary Arweave wallets:
+    1. `cd` into the `wallets` directory (at the root of this repo).
+    1. Run `generateAll.sh` to create new wallets for everything.
+        - _See [wallets/README.md](wallets/README.md) for more details._
+    1. Run `printWalletAddresses.mjs` to list the addresses. _(Useful for step 4, below.)_
+1. Boot up the localnet:
+    1. Run `docker compose up --detach`.
+        - _You will need to have the Docker daemon running._
+        - _This could take a while the first time you run it._
+      - You will have many services now bound to ports in the 4000 range (all subject to change):
+          - http://localhost:4000/ - ArLocal (Arweave gateway/mock)
+          - http://localhost:4007/ - A simple Arweave bundler/uploader
+          - http://localhost:4004/ - An `ao` compute unit (`cu`).
+          - http://localhost:4002/ - An `ao` messenger unit (`cm`).
+          - http://localhost:4003/ - An `ao` schedule unit (`su`).
+1. Seed data onto the blockchain:
+    1. `cd` into the `seed` directory (at the root of this repo).
+    1. Run `./download-aos-module.sh` to pull a WASM binary from testnet.
+    1. Set your wallet addresses _(from step 2, above)_ in `./seed-for-aos.sh`, then run it.
+1. Run `aos`:
+    1. `cd` into the `aos` directory (at the root of this repo).
+    1. Run `./aos`.
 
-1. Clone this repo and `cd` into the root. 
-1. Setup the Arweave wallets that the `ao` components will use to talk to each other:
-    1. Execute `wallets/generateAll.sh` to create new wallets for everything.
-        - _See [wallets/README.md](wallets/README.md) for more advanced configuration._
-1. Use Docker Compose to boot up the `ao` localnet containers:
-    1. Run `docker compose up --detach`
-        - _(You will need to have the Docker daemon running.)_
-        - _(This could take a while the first time you run it.)_
-1. You will have many services now bound to ports in the 4000 range (all subject to change):
-    - http://localhost:4000/ - ArLocal (Arweave gateway)
-    - http://localhost:4001/ - ArDrive Web
-    - http://localhost:4002/ - An `ao` `mu`
-    - http://localhost:4003/ - An `ao` `su`
-    - http://localhost:4004/ - An `ao` `cu`
-    - http://localhost:4005/ - Turbo (Arweave uploader/bundlr)
-    - http://localhost:4006/ - ScAR (Arweave block explorer)
-1. Next, you will likely want to seed data into Arweave. Some options here:
-    1. `cd` into the `services/arlocal/scripts` helper scripts directory.
-    1. Run `npm install` to install dependencies.
-    1. Run `./generate-wallet.mjs` to generate a user wallet in the currently directory.
-        - _(This is logically separate from the wallets that the `ao` components use.)_
-    1. Run `./mint.mjs [winston]` to give AR to your user wallet.
-        - _(If omitted, the default is 1 billion winston, i.e. 1 AR)._
-    1. Run `./create-drive.mjs` to use the `ardrive-core-js` lib to create a new ArDrive drive and
-       root folder.
-    1. Run `./mine.mjs` to mine the ArDrive transactions from the previosu step into a new block.
-1. Try to boot `aos`:
-    - _(There will soon be an script in this directory with which to invoke `aos`.)_
+## Additional Services
+
+> [!NOTE]
+> You can optionally enable the following services.
+> Powered by [Docker Compose profiles](https://docs.docker.com/compose/profiles/)
+
+- ScAR (Arweave block explorer):
+  - Run `docker compose --profile explorer up`.
+  - http://localhost:4006/
+- ArDrive Web:
+  - Run `docker compose --profile ardrive up`.
+  - http://localhost:4001/
+- Turbo Upload Service (an Arweave uploader/bundlr):
+  - Run `docker compose --profile turbo up`.
+  - http://localhost:4005/ 
+  - _Not fully functional. See below for more details._
 
 ## Development Status of this Repo
 
-> [!NOTE]
-> Approximately 80-90% operational, as the `ao` components are running, but not playing nicely with
-each other yet.
+> [!WARNING]
+> `ao` and `aos` are have just started working, but configuration (such as port mappings) will change soon
+> and more usability features are planned.
 
-- ✅ ArLocal instance mocking Arweave and acting as Arweave gateway
+- ✅ ArLocal instance mocking Arweave and acting as Arweave gateway.
   - ℹ️ There are some features missing from [the upstream](https://github.com/textury/arlocal)
     that tend to be used by block explorers, so we are using
     [this fork](https://github.com/MichaelBuhler/arlocal), which fixes:
-    - ✅ Getting pending transactions via `GET /tx/pending` route
+    - ✅ Added `GET /tx/pending` to fetch pending transaction ids
+    - ✅ Added `GET /raw/:txid` to download raw transaction data
+    - ✅ Fix some bugs in chunk uploading/downloading
     - ⬜ Blocks don't include `block_size` ([#1](https://github.com/MichaelBuhler/arlocal/issues/1))
     - ⬜ Blocks don't include `reward_addr` ([#3](https://github.com/MichaelBuhler/arlocal/issues/3))
     - ⬜ Blocks don't include `weave_size` ([#2](https://github.com/MichaelBuhler/arlocal/issues/2))
-- ✅ Arweave block explorer (web interface)
+- ✅ Arweave block explorer (web interface).
   - ✅ ScAR - A lightweight option from [here](https://github.com/renzholy/scar),
-    forked [here](https://github.com/MichaelBuhler/scar) with improvements.
+    forked [here](https://github.com/MichaelBuhler/scar), with improvements.
   - ⬜ ArweaveWebWallet - Another option from [here](https://github.com/jfbeats/ArweaveWebWallet)
     which powers https://arweave.app/.
+- ✅ Fully functional `ao` computer, using the
+  [reference implementations](https://github.com/permaweb/ao/servers).
+  - ✅ `cu`
+  - ✅ `mu`
+  - ✅ `su`
+- ✅ Successfully launching `aos` processes on the `ao` localnet.
+- ⬜ Live reloading for `cu` and `mu` development.
+  - _A cool [feature](https://docs.docker.com/compose/compose-file/develop/) of Docker Compose._
+- ⬜ nginx reverse proxy, for hostname routing
+  - Currently in testing. [This](https://hub.docker.com/r/nginxproxy/nginx-proxy) looks promising.
+- ⬜ DNS routing
+  - ✅ Routing `*.ao-localnet.xyz` to `127.0.0.1` and `::1`
+  - ℹ️ All containers should be reachable via `*.ao-localnet.xyz` domain names.
 - ⚠️ Fully functional ArDrive Web (web interface)
   - ℹ️ Two minor issues remaining:
     - ⏳ Waiting on [this issue](https://github.com/ardriveapp/arweave-dart/issues/59), which causes ArDrive
       Web to makes calls the Arweave gateway on the wrong port.
+      - ✅ Scheduled for [the next release (v3.8.4)](https://github.com/ardriveapp/arweave-dart/pull/61).
     - ⚠️ ArDrive Web is using so-called "sandboxed urls" where it contacts the gateway on a subdomain that is
       the base32 encoded transaction id of the Arweave transaction.
       - _This can be mitigated by adding `127.0.0.1 *.localhost` to your `/etc/hosts` file._
-- ⚠️ Fully functional `ao` computer, using the
-  [reference implementations](https://github.com/permaweb/ao/servers).
-  - `cu`
-    - ✅ Builds and boots.
-  - `mu`
-    - ✅ Builds and boots.
-    - ❌ Returns a 500 error when launching `aos` process. _Error: ao-mu:POST_root Failed to send the
-      DataItem TypeError: f is not a function_
-  - `su`
-    - ✅ Builds and boots.
-- ⚠️ Successfully launching `aos` processes on the `ao` localnet
-  - ℹ️ Some of this code is not committed yet, but I currently have an error in the `mu` when
-    launching `aos` -@MichaelBuhler
-- ⬜ nginx reverse proxy, for hostname routing
-- ⬜ DNS routing
-  - ℹ️ A containers should be reachable via `*.ao-localnet.xyz` domain names.
+      - _Possibly can be fixed with DNS routing, see above._

--- a/aos/.gitignore
+++ b/aos/.gitignore
@@ -1,0 +1,1 @@
+/package-lock.json

--- a/aos/aos
+++ b/aos/aos
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+AOS_BIN=node_modules/.bin/aos
+AOS_WALLET_FILE=../wallets/aos-wallet.json
+SCHEDULER_LOCATION_PUBLISHER_WALLET_FILE=../wallets/scheduler-location-publisher-wallet.json
+
+cd $(dirname $0)
+
+for wallet in $AOS_WALLET_FILE $SCHEDULER_LOCATION_PUBLISHER_WALLET_FILE; do
+  if [ ! -f "$wallet" ]; then
+    echo "wallet does not exist: $(pwd)/$wallet"
+    exit 1
+  fi
+done
+
+if [ ! -f "$AOS_BIN" ]; then
+  npm install
+fi
+
+# TODO: need to find this module id programatically with a query to Arlocal
+AOS_MODULE=eWg6Vd4eSFaPbvxqP_M3sYDncam0-Aq6dsAcsf4U3yY 
+echo "!!!"
+echo "!!!"
+echo "!!!"
+echo "!!!                 $AOS_MODULE"
+echo "!!!"
+echo "!!! using aos module ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+echo "!!! please make sure"
+echo "!!! this is correct!"
+echo "!!!"
+echo "!!!"
+echo "!!!"
+ARWEAVE_GRAPHQL=http://localhost:4000/graphql
+CU_URL=http://localhost:4004
+GATEWAY_URL=http://localhost:4000
+MU_URL=http://localhost:4002
+# The SCHEDULER env var should be set to the wallet address that published the 'Scheduler-Location' tag
+SCHEDULER=$(
+node --input-type=module <<EOF
+  import { readFile } from 'node:fs/promises'
+  import Arweave from 'arweave'
+  const arweave = new Arweave({
+    protocol: 'http',
+    host: 'localhost',
+    port: 4000,
+  })
+  const walletJson = await readFile('$SCHEDULER_LOCATION_PUBLISHER_WALLET_FILE', 'utf8')
+  const wallet = JSON.parse(walletJson)
+  const address = await arweave.wallets.getAddress(wallet)
+  console.log(address)
+EOF
+)
+
+echo AOS_MODULE=$AOS_MODULE
+echo ARWEAVE_GRAPHQL=$ARWEAVE_GRAPHQL
+echo CU_URL=$CU_URL
+echo GATEWAY_URL=$GATEWAY_URL
+echo MU_URL=$MU_URL
+echo SCHEDULER=$SCHEDULER
+export AOS_MODULE
+export ARWEAVE_GRAPHQL
+export CU_URL
+export GATEWAY_URL
+export MU_URL
+export SCHEDULER
+$AOS_BIN --wallet "$AOS_WALLET_FILE"

--- a/aos/package.json
+++ b/aos/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@permaweb/aos": "permaweb/aos#MichaelBuhler/improvement-environment-variables"
+  }
+}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,7 @@
+services:
+  cu:
+    develop:
+  mu:
+    develop:
+  su:
+    develop:

--- a/seed/download-aos-module.sh
+++ b/seed/download-aos-module.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# TODO: need to find this module id programatically with a query to Arlocal
+AOS_MODULE=SBNb1qPQ1TDwpD_mboxm2YllmMLXpWw4U8P9Ff8W9vk
+echo "!!!"
+echo "!!!"
+echo "!!!"
+echo "!!!                      $AOS_MODULE"
+echo "!!!"
+echo "!!! downloading this aos ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+echo "!!! module from testnet"
+echo "!!!"
+echo "!!!"
+echo "!!!"
+
+curl -L https://arweave.net/$AOS_MODULE -o extras/aos.wasm

--- a/seed/publish-aos-module.mjs
+++ b/seed/publish-aos-module.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises'
+
+import { instance as arweave } from './utils/arweave.mjs'
+
+const wallet = JSON.parse(await readFile(import.meta.resolve('../wallets/aos-module-publisher-wallet.json').slice(7), 'utf8'))
+const address = await arweave.wallets.getAddress(wallet)
+
+console.log('aos publisher address:', address)
+
+const tx = await arweave.createTransaction({
+  data: await readFile('extras/aos.wasm'),
+})
+
+tx.addTag('Memory-Limit',    '500-mb'                   )
+tx.addTag('Compute-Limit',   '9000000000000'            )
+tx.addTag('Data-Protocol',   'ao'                       )
+tx.addTag('Type',            'Module'                   )
+tx.addTag('Module-Format',   'wasm32-unknown-emscripten')
+tx.addTag('Input-Encoding',  'JSON-1'                   )
+tx.addTag('Output-Encoding', 'JSON-1'                   )
+tx.addTag('Variant',         'ao.LN.1'                  )
+tx.addTag('Content-Type',    'application/wasm'         )
+
+await arweave.transactions.sign(tx, wallet)
+
+console.log('POST /tx')
+
+const res = await arweave.transactions.post(tx)
+
+if (res.status === 200) {
+  console.log(`${res.status} ${res.statusText}`)
+  console.log(`aos module: ${tx.id}`)
+} else {
+  console.log(`${res.status} ${JSON.stringify(res.statusText, null, 2)}`)
+}

--- a/seed/seed-for-aos.sh
+++ b/seed/seed-for-aos.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+#########################################################################################
+# Mint/grant tokens
+
+# # Give the Scheduler Location Publisher 1 AR
+# curl -q http://localhost:4000/mint/W8_WUWr_xaR9T8JwKwd-b861aq3W2iD3eVeaV_jOn-U/1000000000000
+# echo
+# # Give the `aos` Module Publisher 1 AR
+# curl -q http://localhost:4000/mint/OVH7RgGAzjOxqUPaWjYf1MTrnznM1zpSOTMfC78DpKc/1000000000000
+# echo
+# # Give the bundler service 1 AR
+# curl -q http://localhost:4000/mint/a55QnqSWizpWEnkTcPIijNYwuzTmk-TXTbXTM-CgjDc/1000000000000
+# echo
+# # Give the `ao` units 1 AR
+# curl -q http://localhost:4000/mint/JYti9w4-nAFUUAo7fE0gh4xcv_YxhNad-3Yj7pZbxP0/1000000000000
+# echo
+
+echo "!!!"
+echo "!!!"
+echo "!!!"
+echo "!!! Edit this script to grant tokens to your wallet(s)."
+echo "!!!"
+echo "!!!"
+echo "!!!"
+
+#########################################################################################
+# Publish the 'Scheduler-Location' record
+
+./publish-scheduler-location.mjs
+./mine.mjs
+
+#########################################################################################
+# Publish the `aos` Module
+
+./publish-aos-module.mjs
+echo
+echo "copy this   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+echo
+./mine.mjs

--- a/wallets/printWalletAddresses.mjs
+++ b/wallets/printWalletAddresses.mjs
@@ -2,15 +2,17 @@
 
 import { createHash } from 'node:crypto'
 import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
 
-const dirents = await readdir('.', { withFileTypes: true })
+const walletDir = import.meta.resolve('.').slice(7)
+const dirents = await readdir(walletDir, { withFileTypes: true })
 
 dirents.sort((a, b) => a.name.localeCompare(b.name))
 
 for await (const dirent of dirents) {
   if (dirent.isFile()) {
     const { name: fileName } = dirent
-    const fileContents = await readFile(fileName, 'utf-8')
+    const fileContents = await readFile(join(walletDir, fileName), 'utf-8')
     try {
       const wallet = JSON.parse(fileContents)
       const { n: owner } = wallet


### PR DESCRIPTION
The wrapper/launcher script is needed to set up the env vars that `aos` uses to communicate with `ao`.

Also update documentation.