### PR TITLE
Fix: new su build with rocksdb

### DIFF
--- a/aos/package.json
+++ b/aos/package.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
     "@permaweb/aos": "https://get_ao.g8way.io"
+  },
+  "overrides": {
+    "@permaweb/aoconnect": "^0.0.56"
   }
 }

--- a/services/su/.env
+++ b/services/su/.env
@@ -3,5 +3,9 @@ DATABASE_URL=postgresql://su_user:su_pass@su-database/su_db
 GATEWAY_URL=http://arlocal
 UPLOAD_NODE_URL=http://bundler/
 MODE=su
-# SCHEDULER_LIST_PATH is used when MODE=router
-SCHEDULER_LIST_PATH=""
+SCHEDULER_LIST_PATH="" # used when MODE=router
+# DB_WRITE_CONNECTIONS=10 # how many db connections in the writer pool,defaults to 10
+# DB_READ_CONNECTIONS=10 # how many db connections in the reader pool, default to 10
+USE_DISK=true # whether or not to write and read rocksdb, this is a performance enhancement for the data storage layer
+SU_DATA_DIR=/app/rocksdb # if USE_DISK is true, this is where rocksdb will be initialized
+# MIGRATION_BATCH_SIZE= # when running the migration binary how many to fetch at once from postgres

--- a/services/su/Dockerfile
+++ b/services/su/Dockerfile
@@ -10,6 +10,13 @@ FROM rust AS builder
 WORKDIR /build
 COPY --from=downloader /download/ao/servers/su .
 
+# Install required dependencies for building
+RUN apt update && apt install -y \
+    llvm-dev \
+    libclang-dev \
+    clang \
+    librocksdb-dev
+
 RUN cargo build --release
 
 FROM rust:slim


### PR DESCRIPTION
Needed some changes to be able to build the latest SU binary.
- Add CLANG & LLVM packages during build phase
- Add `USE_DISK` & `SU_DATA_DIR` env vars

Extra fix:
- Force usage of latest (at the time of writing this) `@permaweb/aoconnect` package which fixes issues encountered where aoconnect would attempt to fetch the module location from the web/testnet